### PR TITLE
Add new `deploy.yml` shared workflow with new GitHub environment name and URL inputs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+# Deploy the caller repo's Docker image (from Docker Hub) to Elastic Beanstalk.
+name: Deploy
+permissions:
+  id-token: write  # Required to use AWS OIDC auth.
+on:
+  workflow_call:
+    inputs:
+      github_environment_name:
+        type: string
+        description: "The GitHub environment name to reference, e.g. 'qa' or 'prod'"
+      github_environment_url:
+        type: string
+        description: "The GitHub environment URL to reference, e.g. 'https://qa-lms.hypothes.is/'"
+      aws_region:
+        type: string
+        required: true
+        description: "The AWS region to deploy to, e.g. 'us-west-1' or 'ca-central-1'"
+      elasticbeanstalk_application:
+        type: string
+        required: true
+        description: "The Elastic Beanstalk application to deploy to, e.g. 'via' or 'lms'"
+      elasticbeanstalk_environment:
+        type: string
+        required: true
+        description: "The Elastic Beanstalk environment to deploy to, e.g. 'qa' or 'prod'"
+      docker_tag:
+        type: string
+        description: "The Docker tag to deploy, e.g. '20221019-g8a52aea'"
+      operation:
+        type: string
+        required: true
+        description: "The operation to perform: `deploy` to deploy the given `docker_tag`; `redeploy` to re-deploy the current version of the app; or `sync-env` to synchronize the Elastic Beanstalk environment definition"
+    secrets:
+      DEPLOYMENT_AWS_ROLE_ARN:
+        required: true
+        description: "The ARN for the AWS IAM role configured for use with GitHub Deployments"
+      DEPLOYMENT_REPOSITORY:
+        required: true
+        description: "The GitHub repository containing Elastic Beanstalk environment definitions"
+      DEPLOYMENT_REPOSITORY_KEY:
+        required: true
+        description: "The access key for the respository defined by DEPLOYMENT_REPOSITORY"
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.github_environment_name }}
+      url: ${{ inputs.github_environment_url }}
+    steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE_ARN }}
+        role-duration-seconds: 900
+        aws-region: us-west-1
+    - name: Checkout deployment repo
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ secrets.DEPLOYMENT_REPOSITORY }}
+        ssh-key: ${{ secrets.DEPLOYMENT_REPOSITORY_KEY }}
+    - run: pip install boto3 pyaml
+    - name: Run deploy script
+      run: ./bin/init.sh
+      env:
+        APP: ${{ inputs.elasticbeanstalk_application }}
+        TYPE: ${{ inputs.operation }}
+        APP_DOCKER_VERSION: ${{ inputs.docker_tag }}
+        ENV: ${{ inputs.elasticbeanstalk_environment }}
+        REGION: ${{ inputs.aws_region }}


### PR DESCRIPTION
Part of https://github.com/hypothesis/via/issues/820 and https://github.com/hypothesis/via/issues/821.

Add a new `deploy.yml` shared workflow which is similar to the existing `eb-update.yml` workflow but allows the caller to provide the GitHub environment name and URL as inputs.

This will enable us to change the caller workflows in each of our app repos one-by-one to call the new `deploy.yml` workflow instead of `eb-update.yml`, correcting the GitHub environment names and adding environment URLs to each app repo one by one. Once all app repos have been moved over we can then finally delete the original `eb-update.yml`.

<details>
<summary>

# How `eb-update.yml` currently works
</summary>

`eb-update.yml` has a [single input named `Environment`](https://github.com/hypothesis/workflows/blob/2aea5616abf737354d63e2dd9905f1474c036562/.github/workflows/eb-update.yml#L11-L14) that it uses for two purposes:

1. The `Environment` input is [used as the value of the the `ENV` environment variable](https://github.com/hypothesis/workflows/blob/2aea5616abf737354d63e2dd9905f1474c036562/.github/workflows/eb-update.yml#L42) that is passed to the [`deployment` repo's `init.sh` script](https://github.com/hypothesis/deployment/blob/main/bin/init.sh).

   It looks like `init.sh` currently [forces `ENV` to be either `"qa"` or `"prod"`](https://github.com/hypothesis/deployment/blob/df251c6fc748056fcc65c9b16f2e41427843337f/bin/init.sh#L53-L56), hence `eb-update.yml`'s `Environment` input must also be either `"qa"` or `"prod"`.

   If doing a deployment `init.sh` passes `ENV` to the [`eb-deploy` script](https://github.com/hypothesis/deployment/blob/main/bin/eb-deploy) which [constructs the Elastic Beanstalk environment name](https://github.com/hypothesis/deployment/blob/df251c6fc748056fcc65c9b16f2e41427843337f/bin/eb-deploy#L51) by combining `APP` and `ENV`: `aws elasticbeanstalk update-environment --application-name "$APP" --environment-name "${APP}-${ENV}"`.

   So for example `APP` might be `via` and `ENV` might be `prod`, resulting in an Elastic Beanstalk environment name of `via-prod`. All our Elastic Beanstalk environment names have this `{APP}-{ENV}` format where the environment name always begins with the app name: `lms-qa`, `h-prod`, etc.

   (`APP` originates from another input of the `eb-update.yml` shared workflow: [`inputs.Application`](https://github.com/hypothesis/workflows/blob/2aea5616abf737354d63e2dd9905f1474c036562/.github/workflows/eb-update.yml#L41).)

2. Secondly, `eb-update.yml`'s `Environment` input is also [used as the GitHub environment name](https://github.com/hypothesis/workflows/blob/2aea5616abf737354d63e2dd9905f1474c036562/.github/workflows/eb-update.yml#L50).

   This means that all our apps can only have two GitHub environments and they must be named `qa` and `prod`. This is a problem because [we actually need to create a separate GitHub environment for each Elastic Beanstalk environment](https://github.com/hypothesis/via/issues/820) and many of our apps have more than just two Elastic Beanstalk environments named `qa` and `prod`.
</details>

<details>
<summary>

# How the new `deploy.yml` works
</summary>

The new `deploy.yml` accepts the `ENV` variable for `init.sh`, the GitHub environment name, and the GitHub environment URL as three separate inputs named `elasticbeanstalk_environment`, `github_environment_name` and `github_environment_url`. The idea is that the caller workflows in each app will provide each of these values separately for each environment. For example Via's caller workflow might look something like this:

```yaml
QA:
  uses: hypothesis/workflows/.github/workflows/deploy.yml@main
  with:
    operation: deploy
    github_environment_name: QA
    github_environment_url: https://qa-lms.hypothes.is
    aws_region: us-west-1
    elasticbeanstalk_application: via
    elasticbeanstalk_environment: qa
    ...

QA (Edu):
  uses: hypothesis/workflows/.github/workflows/deploy.yml@main 
  with:
    operation: deploy
    github_environment_name: QA (Edu)
    github_environment_url: https://???
    aws_region: us-west-1
    elasticbeanstalk_application: lms-via
    elasticbeanstalk_environment: qa
    ...

Production:
    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
    with:
      operation: deploy
      github_environment_name: Production
      github_environment_url: https://lms.hypothes.is
      aws_region: us-west-1
      elasticbeanstalk_application: via
      elasticbeanstalk_environment: prod
      ...

Production (Edu):
    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
    with:
      operation: deploy
      github_environment_name: Production (Edu)
      github_environment_url: https://???
      aws_region: us-west-1
      elasticbeanstalk_application: lms-via
      elasticbeanstalk_environment: prod
      ...
```
</details>

<details>
<summary>

# Why create a new workflow?
</summary>

Adding new `github_environment_name` and `github_environment_url` inputs to the existing `eb-update.yml` workflow inputs would break all the caller workflows in our apps and deployments would be broken until all the caller workflows could be fixed. There are a few options:

1. I could add the new inputs to `eb-update.yml` with a backwards-compatible fallback behaviour, then update the caller workflows one-by-one, then remove the fallback behaviour.

2. I could write a new workflow to replace `eb-update.yml`, change the caller workflows one-by-one to call the new workflow instead, and then delete the original `eb-update.yml`.

3. I could change all the `@{ref}`'s whenever any of the caller workflows calls `eb-update.yml` to pin them to a specific commit rather than main. For example:

   ```yaml
   jobs: qa: uses: hypothesis/workflows/.github/workflows/eb-update.yml@2aea5616abf737354d63e2dd9905f1474c036562
   ```

   I could then make the breaking change to `eb-update.yml` and one-by-one update each caller workflow to work with the new version and update the `@{ref}`.

In this commit I've gone with option 2.