### PR TITLE
Return the Docker tag to the caller workflow

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -17,6 +17,10 @@ on:
       DEPLOYMENT_DOCKER_USER_KEY:
         required: true
         description: "The access key for the user defined by DEPLOYMENT_DOCKER_USER"
+    outputs:
+      docker_tag:
+        description: "The tag (version number) of the image that was published to Docker Hub."
+        value: ${{ jobs.DockerHub.outputs.docker_tag }}
 
 env:
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -26,9 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     env:
       name: ${{ inputs.Application }}
+    outputs:
+      docker_tag: ${{ steps.build.outputs.docker_tag }}
     steps:
       - uses: actions/checkout@v3
       - name: build
+        id: build
         run: |
           GIT_SHORT=$(git rev-parse --short HEAD)
           GIT_COMMIT_TIMESTAMP=$(git --no-pager show -s --format=%ct $GIT_SHORT)
@@ -36,6 +43,7 @@ jobs:
           VERSION=$(echo "$GIT_TS_CONVERTED-g$GIT_SHORT")
           export TAG=${VERSION//+/-}
           echo "::set-env name=TAG::$TAG"
+          echo "docker_tag=${TAG}" >> $GITHUB_OUTPUT
           git archive HEAD | docker build -t "hypothesis/${name}:${TAG}" -
       - name: push
         run: |


### PR DESCRIPTION
`dockerhub.yml` shared workflow: return the tag (version number) of the image that was published to the caller workflow.

Fixes https://github.com/hypothesis/workflows/issues/5

I don't think there's any way to know whether this works without first merging this PR and then also merging a PR in one of our apps to change the caller workflow to attempt to use the tag.

I'm attempting to follow the docs here:

https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-outputs-from-a-reusable-workflow
