### PR TITLE
Matched AWS ODIC timeout with task being executed

### DIFF
--- a/.github/workflows/eb-task.yml
+++ b/.github/workflows/eb-task.yml
@@ -73,7 +73,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v1
       with:
         role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE_ARN }}
-        role-duration-seconds: 900
+        role-duration-seconds: ${{ inputs.Timeout }}
         aws-region: us-west-1
     - name: Checkout deployment repo
       uses: actions/checkout@v3


### PR DESCRIPTION
We need to run long jobs through eb-task.yml and the `900` second hard coded timeout on the AWS ODIC token was expiring before the timeout of the SQL task being run. This PR matches these two timeouts.

Will need testing, but I think it should do the trick.

#### Additional info

https://hypothes-is.slack.com/archives/C042JM4SPD0/p1666873165866049?thread_ts=1666807847.691159&cid=C042JM4SPD0