### PR TITLE
Set deploy job name to environment name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,7 @@ on:
         description: "The access key for the respository defined by DEPLOYMENT_REPOSITORY"
 jobs:
   Deploy:
+    name: ${{ inputs.github_environment_url }}
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.github_environment_name }}


### PR DESCRIPTION
On workflow pages the jobs for deploying to various environments like
"QA", "Production" or "Production (Canada)" are all just being labelled
as "Deploy". Try setting the job name to the GitHub environment name
instead so that you'll be able to see which job is deploying to which
environment.
