### PR TITLE
Rename the deploy job to just "Deploy"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,6 @@ on:
         description: "The access key for the respository defined by DEPLOYMENT_REPOSITORY"
 jobs:
   Deploy:
-    name: ${{ inputs.github_environment_name }}
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.github_environment_name }}


### PR DESCRIPTION
This is better names "Deploy" rather than using the environment name
(e.g. "Production (Canada)") because the caller job should already be
named after the environment so it'll appear as
"Production (Canada) / Deploy" rather than
"Production (Canada) / Production (Canada)".
