### PR TITLE
Don't push the `latest` tag for Docker Hub

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -49,5 +49,3 @@ jobs:
         run: |
           echo "${{ secrets.DEPLOYMENT_DOCKER_USER_KEY }}" | docker login -u "${{ secrets.DEPLOYMENT_DOCKER_USER }}"  --password-stdin
           docker push "hypothesis/${name}:${TAG}"
-          docker tag "hypothesis/${name}:${TAG}" "hypothesis/${name}:latest"
-          docker push "hypothesis/${name}:latest"


### PR DESCRIPTION
This tag might be misleading in certain edge cases and I don't think we use it for anything. See:

https://hypothes-is.slack.com/archives/CR3E3S7K8/p1668697789688469?thread_ts=1668697371.459739&cid=CR3E3S7K8