### PR TITLE
Switch AWS actions to a version using node 16

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
       url: ${{ inputs.github_environment_url }}
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE_ARN }}
         role-duration-seconds: 900

--- a/.github/workflows/eb-task.yml
+++ b/.github/workflows/eb-task.yml
@@ -70,7 +70,7 @@ jobs:
         region: ${{ fromJson(needs.set_region.outputs.region_matrix) }}
     steps:
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE_ARN }}
         role-duration-seconds: ${{ inputs.Timeout }}

--- a/.github/workflows/eb-update.yml
+++ b/.github/workflows/eb-update.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE_ARN }}
         role-duration-seconds: 900


### PR DESCRIPTION
AWS does not yet provide a `v2` for their actions, nor they plan to update to node 16 on `v1`.

Instead, they provide an alternative branch `v1-node16` which they promise will have the same features and fixes as the regular `v1`, but running on node 16.

See https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning