### PR TITLE
Fix node 16 warnings by updating to latest GitHub Actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,13 +48,13 @@ jobs:
       url: ${{ inputs.github_environment_url }}
     steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE_ARN }}
         role-duration-seconds: 900
         aws-region: us-west-1
     - name: Checkout deployment repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ secrets.DEPLOYMENT_REPOSITORY }}
         ssh-key: ${{ secrets.DEPLOYMENT_REPOSITORY_KEY }}

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       docker_tag: ${{ steps.build.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: build
         id: build
         run: |

--- a/.github/workflows/eb-task.yml
+++ b/.github/workflows/eb-task.yml
@@ -70,13 +70,13 @@ jobs:
         region: ${{ fromJson(needs.set_region.outputs.region_matrix) }}
     steps:
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE_ARN }}
         role-duration-seconds: ${{ inputs.Timeout }}
         aws-region: us-west-1
     - name: Checkout deployment repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ secrets.DEPLOYMENT_REPOSITORY }}
         ssh-key: ${{ secrets.DEPLOYMENT_REPOSITORY_KEY }}

--- a/.github/workflows/eb-update.yml
+++ b/.github/workflows/eb-update.yml
@@ -51,13 +51,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: configure aws credentials
-      uses: aws-actions/configure-aws-credentials@v1-node16
+      uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ secrets.DEPLOYMENT_AWS_ROLE_ARN }}
         role-duration-seconds: 900
         aws-region: us-west-1
     - name: Checkout deployment repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: ${{ secrets.DEPLOYMENT_REPOSITORY }}
         ssh-key: ${{ secrets.DEPLOYMENT_REPOSITORY_KEY }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: python3 -m pip install --upgrade build && python3 -m build


### PR DESCRIPTION
Fix deprecation warnings across most of our workflows by:

* Updating all standard actions from v3 to v4, that use node 20 instead of node 16
* Update AWS actions from v1-node16 to v4. Looks like a big jump, but the most outstanding changes are the update to node 20:
  * v2 updated from node 12 to node 16. v1-node16 was a temporary workaround
  * v3 introduced a couple changes, but none seem relevant to us on first sight. They can be found here though: https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#v3-announcement-82323
  * v4 updates from node 16 to node 20