### PR TITLE
Use a virtualenv to install boto3 and pyaml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,12 +58,11 @@ jobs:
       with:
         repository: ${{ secrets.DEPLOYMENT_REPOSITORY }}
         ssh-key: ${{ secrets.DEPLOYMENT_REPOSITORY_KEY }}
-    - run: |
-        python -m venv .venv
-        .venv/bin/pip install boto3 pyaml
-    - name: Run deploy script
+    - name: Install dependencies and run deploy script
       run: |
+        python -m venv .venv
         source .venv/bin/activate
+        pip install boto3 pyaml
         ./bin/init.sh
       env:
         APP: ${{ inputs.elasticbeanstalk_application }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,9 +58,13 @@ jobs:
       with:
         repository: ${{ secrets.DEPLOYMENT_REPOSITORY }}
         ssh-key: ${{ secrets.DEPLOYMENT_REPOSITORY_KEY }}
-    - run: pip install boto3 pyaml
+    - run: |
+        python -m venv .venv
+        .venv/bin/pip install boto3 pyaml
     - name: Run deploy script
-      run: ./bin/init.sh
+      run: |
+        source .venv/bin/activate
+        ./bin/init.sh
       env:
         APP: ${{ inputs.elasticbeanstalk_application }}
         TYPE: ${{ inputs.operation }}


### PR DESCRIPTION
This is an attempt to fix this error that has started happening with
deployments, probably as a result of GitHub updating their
`ubuntu-latest` VM:

    error: externally-managed-environment

    × This environment is externally managed
    ╰─> To install Python packages system-wide, try apt install
        python3-xyz, where xyz is the package you are trying to
        install.

        If you wish to install a non-Debian-packaged Python package,
        create a virtual environment using python3 -m venv path/to/venv.
        Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
        sure you have python3-full installed.

        If you wish to install a non-Debian packaged Python application,
        it may be easiest to use pipx install xyz, which will manage a
        virtual environment for you. Make sure you have pipx installed.

        See /usr/share/doc/python3.12/README.venv for more information.

    note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python
